### PR TITLE
Update ReplayVersion6Offsets.py

### DIFF
--- a/spyparty/ReplayVersion6Offsets.py
+++ b/spyparty/ReplayVersion6Offsets.py
@@ -85,7 +85,7 @@ class ReplayVersion6Offsets(ReplayOffsets):
         spy_displayname_length = ord(bytes[0x30])
         sniper_displayname_length = ord(bytes[0x31])
         if sniper_displayname_length == 0:
-            return self.extract_spy_username(bytes)
+            return self.extract_sniper_username(bytes)
         else:
             return self._read_bytes(bytes, 0x64 + spy_username_length + sniper_username_length + spy_displayname_length, sniper_displayname_length)
 


### PR DESCRIPTION
for 0 length sniper display names, it was previously extracting the spy username instead of sniper username