### PR TITLE
Fixing bug in parsing known modes

### DIFF
--- a/spyparty/ReplayParser.py
+++ b/spyparty/ReplayParser.py
@@ -113,7 +113,7 @@ class ReplayParser:
 
         real_mode = MODE_MAP[mode]
         if real_mode == "k":
-            return "k" + str(available)
+            return "k" + str(required)
 
         return "%s%d/%d" % (real_mode, required, available)
 


### PR DESCRIPTION
Previously, known modes would should up as K0 because available is 0 in K modes, but required is populated.