### PR TITLE
Refactor imports

### DIFF
--- a/spyparty/ReplayOffsets.py
+++ b/spyparty/ReplayOffsets.py
@@ -1,6 +1,6 @@
 import struct
 
-from abc import ABCMeta, abstractmethod
+from abc import abstractmethod
 
 
 # TODO:

--- a/spyparty/ReplayParser.py
+++ b/spyparty/ReplayParser.py
@@ -4,10 +4,10 @@ import struct
 import datetime
 import base64
 
-from ReplayVersion3Offsets import ReplayVersion3Offsets
-from ReplayVersion4Offsets import ReplayVersion4Offsets
-from ReplayVersion5Offsets import ReplayVersion5Offsets
-from ReplayVersion6Offsets import ReplayVersion6Offsets
+from spyparty.ReplayVersion3Offsets import ReplayVersion3Offsets
+from spyparty.ReplayVersion4Offsets import ReplayVersion4Offsets
+from spyparty.ReplayVersion5Offsets import ReplayVersion5Offsets
+from spyparty.ReplayVersion6Offsets import ReplayVersion6Offsets
 
 FILE_VERSION = 3
 

--- a/spyparty/ReplayVersion3Offsets.py
+++ b/spyparty/ReplayVersion3Offsets.py
@@ -1,4 +1,4 @@
-from ReplayOffsets import ReplayOffsets
+from spyparty.ReplayOffsets import ReplayOffsets
 
 
 class ReplayVersion3Offsets(ReplayOffsets):

--- a/spyparty/ReplayVersion4Offsets.py
+++ b/spyparty/ReplayVersion4Offsets.py
@@ -1,4 +1,4 @@
-from ReplayOffsets import ReplayOffsets
+from spyparty.ReplayOffsets import ReplayOffsets
 
 
 class ReplayVersion4Offsets(ReplayOffsets):

--- a/spyparty/ReplayVersion5Offsets.py
+++ b/spyparty/ReplayVersion5Offsets.py
@@ -1,4 +1,4 @@
-from ReplayOffsets import ReplayOffsets
+from spyparty.ReplayOffsets import ReplayOffsets
 
 
 class ReplayVersion5Offsets(ReplayOffsets):

--- a/spyparty/ReplayVersion6Offsets.py
+++ b/spyparty/ReplayVersion6Offsets.py
@@ -1,4 +1,4 @@
-from ReplayOffsets import ReplayOffsets
+from spyparty.ReplayOffsets import ReplayOffsets
 
 
 class ReplayVersion6Offsets(ReplayOffsets):


### PR DESCRIPTION
Remove unused import in ReplayOffsets, remove relative imports in other files.  ReplayParser can't be imported by other packages the way it was previously.

P.S. if you want me to do these PRs in a different way, let me know.  I'm just putting them all on branches so you can merge them in any order, but I don't github often, so don't know if that preferred.